### PR TITLE
Release 20.0.1.2

### DIFF
--- a/ACA/configuration-ha/DB2/AddTenant.bat
+++ b/ACA/configuration-ha/DB2/AddTenant.bat
@@ -142,7 +142,7 @@ if /I "%c%" EQU "N" goto :DOEXIT
 	REM load the tenant Db
 	echo "Loading default data into tables"
 	db2 load from CSVFiles\doc_class.csv of del insert into doc_class
-	db2 load from CSVFiles\object_type.csv of del modified by identityoverride insert into object_type;
+	db2 load from CSVFiles\object_type.csv of del modified by identityoverride insert into object_type
 	db2 load from CSVFiles\key_class.csv of del modified by identityoverride insert into key_class
 	db2 load from CSVFiles\doc_alias.csv of del modified by identityoverride insert into doc_alias
 	db2 load from CSVFiles\key_alias.csv of del modified by identityoverride insert into key_alias
@@ -160,7 +160,7 @@ if /I "%c%" EQU "N" goto :DOEXIT
 
     echo --
 	echo "SET INTEGRITY ..."
-	db2 set integrity for key_class immediate checked ;
+	db2 set integrity for key_class immediate checked
 	db2 set integrity for key_class_dc immediate checked
 	db2 set integrity for doc_alias_dc immediate checked
 	db2 set integrity for key_alias_dc immediate checked

--- a/ODM/README_config.md
+++ b/ODM/README_config.md
@@ -31,13 +31,13 @@ The installation of Operational Decision Manager 8.10.3 can be customized by cha
 
 Make a note of the name and value for the different parameters you want to configure so that it is at hand when you enter it in the custom resource YAML file.
 
-Go to the [IBM Cloud Pak for Automation 20.0.x](https://www.ibm.com/support/knowledgecenter/SSYHZ8_20.0.x/com.ibm.dba.install/k8s_topics/tsk_install_odm.html) Knowledge Center and choose which customizations you want to apply.
+Go to the [IBM Cloud Pak for Automation 20.0.x](https://www.ibm.com/support/knowledgecenter/SSYHZ8_20.0.x/com.ibm.dba.offerings/topics/con_odm_prod.html) Knowledge Center and choose which customizations you want to apply.
    * [Defining the security certificate](https://www.ibm.com/support/knowledgecenter/SSYHZ8_20.0.x/com.ibm.dba.offerings/topics/tsk_replace_security_certificate.html)
-   * [Configuring the LDAP and user registry](https://www.ibm.com/support/knowledgecenter/SSYHZ8_20.0.x/com.ibm.dba.offerings/topics/con_config_user_registry.html)
+   * [Configuring user access](https://www.ibm.com/support/knowledgecenter/SSYHZ8_20.0.x/com.ibm.dba.offerings/topics/tsk_config_user_access.html)
    * [Configuring a custom external database](https://www.ibm.com/support/knowledgecenter/SSYHZ8_20.0.x/com.ibm.dba.offerings/topics/tsk_custom_external_db.html)
    * [Configuring the ODM event emitter](https://www.ibm.com/support/knowledgecenter/SSYHZ8_20.0.x/com.ibm.dba.offerings/topics/tsk_custom_emitters.html)
    * [Configuring Decision Center customization](https://www.ibm.com/support/knowledgecenter/SSYHZ8_20.0.x/com.ibm.dba.offerings/topics/tsk_custom_dc.html)
-   * [Configuring Decision Center time zone](https://www.ibm.com/support/knowledgecenter/SSYHZ8_20.0.x/com.ibm.dba.managing/op_topics/tsk_set_jvmargs.html)
+   * [Configuring Decision Center time zone](https://www.ibm.com/support/knowledgecenter/SSYHZ8_20.0.x/com.ibm.dba.offerings/topics/tsk_set_jvmargs.html)
    * [Configuring the execution unit (XU)](https://www.ibm.com/support/knowledgecenter/SSYHZ8_20.0.x/com.ibm.dba.offerings/topics/tsk_configuring_xu.html)
 
 > **Note**: The [configuration](configuration) folder provides sample configuration files that you might find useful. Download the files and edit them for your own customizations.

--- a/UMS/README_config.md
+++ b/UMS/README_config.md
@@ -11,11 +11,12 @@
 
 ## Prerequisites
 
-Make sure that you specified the configuration parameter `sc_deployment_platform` in `shared_configuration`.
+Make sure that you specified the mandatory configuration parameters `appVersion: 20.0.1` in `spec` and `sc_deployment_platform` in `shared_configuration`.
 If you deploy on Red Hat OpenShift, specify
 
 ```yaml
 spec:
+ appVersion: 20.0.1
  shared_configuration:
    sc_deployment_platform: OCP
 ```
@@ -24,9 +25,13 @@ otherwise specify
 
 ```yaml
 spec:
+ appVersion: 20.0.1
  shared_configuration:
    sc_deployment_platform: NonOCP
 ```
+
+For information about shared configuration parameters and sample values refer to 
+[Shared configuration parameters](https://www.ibm.com/support/knowledgecenter/SSYHZ8_20.0.x/com.ibm.dba.ref/k8s_topics/ref_shared_images_params.html).
 
 ## <a name="Step-1"></a> Step 1: Generate the UMS secret
 

--- a/UMS/README_upgrade.md
+++ b/UMS/README_upgrade.md
@@ -84,7 +84,7 @@ stringData:
   tsDBPassword: "!Passw0rd"
 ```
 
-After you have created the secret, update your Custom Resource to configure `ums_configuration.db_secret_name` to point to the secret `ibm-dba-ums-secret`.
+After you have created the secret, update your Custom Resource to configure `ums_configuration.admin_secret_name` to point to the secret `ibm-dba-ums-secret`.
 
 ### New parameters
 The following optional parameters are new in 20.0.1, they support long-lived access tokens. For more information, see Refer to [Using long-lived access tokens](https://www.ibm.com/support/knowledgecenter/SSYHZ8_20.0.x/com.ibm.dba.offerings/topics/con_ums_sso_app_token.html).

--- a/descriptors/ibm_cp4a_cr_template.yaml
+++ b/descriptors/ibm_cp4a_cr_template.yaml
@@ -1447,6 +1447,7 @@ spec:
   #     service_type: "Route"
   #     hostname: ""
   #     port: 443
+  #     workstream_server_secret: ibm-baw-baw-secret
   #     external_tls_secret: ibm-baw-ext-tls-secret
   #     external_tls_ca_secret: ibm-baw-ext-tls-ca-secret
   #     replicas: 1

--- a/platform/k8s/upgrade.md
+++ b/platform/k8s/upgrade.md
@@ -17,7 +17,7 @@ Follow the instructions in step 1 of [Installing Cloud Pak for Automation 20.0.1
    ```
 3. Upgrade the icp4a-operator on your cluster.
 
-   Use the 20.0.1  [scripts/upgradeOperator.sh](../scripts/upgradeOperator.sh) script to deploy the operator manifest descriptors.
+   Use the 20.0.1  [scripts/upgradeOperator.sh](../../scripts/upgradeOperator.sh) script to deploy the operator manifest descriptors.
    ```bash
    $ ./scripts/upgradeOperator.sh -i <registry_url>/icp4a-operator:20.0.1 -p '<my_secret_name>' -a accept
    ```

--- a/platform/ocp/upgrade.md
+++ b/platform/ocp/upgrade.md
@@ -20,7 +20,7 @@ Follow the instructions in step 1 of [Installing Cloud Pak for Automation 20.0.1
    ```
 3. Upgrade the icp4a-operator on your cluster.
 
-   Use the 20.0.1  [scripts/upgradeOperator.sh](../scripts/upgradeOperator.sh) script to deploy the operator manifest descriptors.
+   Use the 20.0.1  [scripts/upgradeOperator.sh](../../scripts/upgradeOperator.sh) script to deploy the operator manifest descriptors.
    ```bash
    $ ./scripts/upgradeOperator.sh -i <registry_url>/icp4a-operator:20.0.1 -p '<my_secret_name>' -a accept
    ```

--- a/platform/roks/upgrade.md
+++ b/platform/roks/upgrade.md
@@ -24,7 +24,7 @@ Follow the instructions in step 1 of [Installing Cloud Pak for Automation 20.0.1
    ```
 4. Upgrade the icp4a-operator on your cluster.
 
-   Use the 20.0.1  [scripts/upgradeOperator.sh](../scripts/upgradeOperator.sh) script to deploy the operator manifest descriptors.
+   Use the 20.0.1  [scripts/upgradeOperator.sh](../../scripts/upgradeOperator.sh) script to deploy the operator manifest descriptors.
    ```bash
    $ ./scripts/upgradeOperator.sh -i <registry_url>/icp4a-operator:20.0.1 -p '<my_secret_name>' -a accept
    ```


### PR DESCRIPTION
Defect Fixes

Id  | Component | Issue
-- | -- | --
1380 | Doc | Link to upgradeOperator.sh on github.com broken
1355  | Doc | Broken link from README.md to KC
1287  | IAWS | Workstream_server_secret is missing in ibm_cp4a_cr_template.yaml
1258  | UMS | Secret name in the update secret step needs to be corrected in the upgrade doc
1184  | IAWS | PFS 19.0.3 to 20.0.1 upgrade fails as the already existing service cannot be patched.