### PR TITLE
Update checkURL4BA.sh

### DIFF
--- a/scripts/helper/post-install/probe/checkURL4BA.sh
+++ b/scripts/helper/post-install/probe/checkURL4BA.sh
@@ -27,8 +27,11 @@ VERBOSE=$6      # verbose option to see additional debug information
   RESET_TEXT=`tput sgr0`
   BOLD_TEXT=`tput bold`
 
-PROB_DIR="$( cd "$( dirname "$0" )" && pwd )"
-cd $PROB_DIR
+# 'dirname' always prints the path, 'cd' can print the path if CDPATH is set.
+ # Set PROB_DIR via 'pwd' only and discard the other path printouts.
+ cd "$( dirname "$0" )" > /dev/null
+ PROB_DIR="$( pwd )"
+ echo "$PROB_DIR"
 
 # Funtion to check if given keyword is returned by URL
 checkURL() {


### PR DESCRIPTION
Prevent duplicate path entries in PROB_DIR
The original code from branch 25.0.0 did not work on my Linux box. PROB_DIR always contained the new path two times separated by a newline. The new code worked as expected.

I stumpled about this executing `./cp4a-post-install.sh --StarterProbe`