### PR TITLE
Revert "CP4BA 25.0.0-IF005"

### DIFF
--- a/descriptors/op-olm/catalog_source.yaml
+++ b/descriptors/op-olm/catalog_source.yaml
@@ -33,7 +33,7 @@ spec:
   publisher: IBM
   sourceType: grpc
   image: >-
-    icr.io/cpopen/ibm-opencontent-flink-operator-catalog@sha256:9f673bd4ab11a5734cdf79bf18c7c5bcb52ded1c7faf9e24e3355f3f6e4edb97
+    icr.io/cpopen/ibm-opencontent-flink-operator-catalog@sha256:d3970f055e5bfbe77cd4fbfa9da86bb39597b9474c19fd0a3190cb568c7534af
   priority: 100
   grpcPodConfig:
     securityContextConfig: restricted

--- a/descriptors/op-olm/catalog_source.yaml
+++ b/descriptors/op-olm/catalog_source.yaml
@@ -22,7 +22,7 @@ spec:
   grpcPodConfig:
     securityContextConfig: restricted
 ---
-# IBM CS Flink Operator Catalog 1.20.2 (2.0.18)
+# IBM CS Flink Operator Catalog 1.20.2 (2.0.19)
 apiVersion: operators.coreos.com/v1alpha1
 kind: CatalogSource
 metadata:
@@ -33,7 +33,7 @@ spec:
   publisher: IBM
   sourceType: grpc
   image: >-
-    icr.io/cpopen/ibm-opencontent-flink-operator-catalog@sha256:d68536ac84dafca1a2041bb5511f487aaf52e239b1be340e79801e5c419e9f44
+    icr.io/cpopen/ibm-opencontent-flink-operator-catalog@sha256:9f673bd4ab11a5734cdf79bf18c7c5bcb52ded1c7faf9e24e3355f3f6e4edb97
   priority: 100
   grpcPodConfig:
     securityContextConfig: restricted

--- a/scripts/airgap/cp4ba-case-to-be-mirrored-25.0.0-IF005.txt
+++ b/scripts/airgap/cp4ba-case-to-be-mirrored-25.0.0-IF005.txt
@@ -40,7 +40,7 @@ cases:
     ocMirror:
       disableMerge: true
 - name: ibm-cs-flink
-  version: 2.0.18
+  version: 2.0.19
   catalogGeneration:
     ocMirror:
       disableMerge: true


### PR DESCRIPTION
Reverts icp4a/cert-kubernetes#87
Since Flink 2.0.19 is now published, reverting to use 2.0.19.